### PR TITLE
Made makefile output pretty and removed hardcoded source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,25 @@
-CXX = g++
-SDL2_CFLAGS = $(shell sdl2-config --cflags)
-SDL2_LIBS= $(shell sdl2-config --libs)
-CXXFLAGS = -std=c++14 -Wall -g $(SDL2_CFLAGS)
-LIBS = -lcryptsetup $(SDL2_LIBS) -lSDL2_ttf
-DEPS = keyboard.h config.h luksdevice.h util.h draw_helpers.h
+SDL2_CFLAGS := $(shell sdl2-config --cflags)
+SDL2_LIBS  := $(shell sdl2-config --libs)
 
-%.o: %.cpp $(DEPS)
-	$(CXX) -c -o $@ $< $(CXXFLAGS)
+CXX        := g++
+CXXFLAGS   := -std=c++14 -Wall -g $(SDL2_CFLAGS)
 
-osk-sdl: main.o keyboard.o config.o util.o luksdevice.o
-	$(CXX) -o $@ $^ $(CXXFLAGS) $(LIBS)
+LIBS       := -lcryptsetup $(SDL2_LIBS) -lSDL2_ttf
+
+SOURCES    := ${wildcard *.cpp}
+OBJECTS    := $(SOURCES:%.cpp=%.o)
+
+all: osk-sdl
+
+%.o: %.cpp
+	@echo CC $<
+	@$(CXX) -c -o $@ $< $(CXXFLAGS)
+
+osk-sdl: $(OBJECTS)
+	@echo LD $@
+	@$(CXX) -o $@ $^ $(CXXFLAGS) $(LIBS)
 
 .PHONY: clean
 
 clean:
-	rm -f *.o osk-sdl
-  
+	-rm -fv *.o osk-sdl


### PR DESCRIPTION
```bash
$ make
CC keyboard.cpp
CC draw_helpers.cpp
CC config.cpp
CC luksdevice.cpp
CC main.cpp
CC util.cpp
LD osk-sdl
$
```
This also removes all hardcoded source files in the makefile, it just builds everything as object and then creates the executable. Also the output from the clean command is made more explicit.

```shell
$ make clean
rm -fv *.o osk-sdl
removed 'config.o'
removed 'draw_helpers.o'
removed 'keyboard.o'
removed 'luksdevice.o'
removed 'main.o'
removed 'util.o'
removed 'osk-sdl'
$
```