### PR TITLE
Improvements to rendering

### DIFF
--- a/draw_helpers.cpp
+++ b/draw_helpers.cpp
@@ -19,30 +19,31 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "draw_helpers.h"
 
-SDL_Point* bezier_corner (SDL_Point*offset,SDL_Point *p1, SDL_Point *p2, SDL_Point *p3) {
-  SDL_Point*pts = (SDL_Point*)malloc(sizeof(SDL_Point) * BEZIER_RESOLUTION);
+SDL_Point* bezier_corner (SDL_Point*pts, SDL_Point*offset,SDL_Point *p1, SDL_Point *p2, SDL_Point *p3) {
   int i = 0;
-  for(double t=0.0; t<=1.0; t+=1/BEZIER_RESOLUTION){
+  static float increment = 1/BEZIER_RESOLUTION;
+
+  for(double t = increment; t <= 1.0; t += increment){
     pts[i].x = ((1-t)*(1-t)*p1->x+2*(1-t)*t*p2->x+t*t*p3->x) + offset->x;
     pts[i].y = ((1-t)*(1-t)*p1->y+2*(1-t)*t*p2->y+t*t*p3->y) + offset->y;
-    i++;
+    ++i;
   }
   return pts;
 }
 
 void smooth_corners(SDL_Rect *rect, int radius,function<void(int,int)> draw_cb){
+    SDL_Point* corner = (SDL_Point*)malloc(sizeof(SDL_Point)*BEZIER_RESOLUTION);
     //Top Left
-    auto corner = bezier_corner(new SDL_Point{rect->x-1,rect->y-1}, new SDL_Point{0,radius},
+    bezier_corner(corner, new SDL_Point{rect->x-1,rect->y-1}, new SDL_Point{0,radius},
       new SDL_Point{0,0},new SDL_Point{radius,0});
     for(int i = 0; i < BEZIER_RESOLUTION; i++){
       for(int x =rect->x; x < corner[i].x; x++){
         draw_cb(x,corner[i].y);
       }
     }
-    free(corner);
 
     //Top Right
-    corner = bezier_corner(new SDL_Point{rect->x + rect->w+1,rect->y-1}, new SDL_Point{0,radius},
+    bezier_corner(corner, new SDL_Point{rect->x + rect->w+1,rect->y-1}, new SDL_Point{0,radius},
       new SDL_Point{0,0},new SDL_Point{-radius,0});
     for(int i = 0; i < BEZIER_RESOLUTION; i++){
       for(int x = rect->x+rect->w; x > corner[i].x; x--){
@@ -51,17 +52,16 @@ void smooth_corners(SDL_Rect *rect, int radius,function<void(int,int)> draw_cb){
     }
 
     //Bottom Left
-    corner = bezier_corner(new SDL_Point{rect->x-1,rect->y + rect->h+1}, new SDL_Point{0,-radius},
+    bezier_corner(corner, new SDL_Point{rect->x-1,rect->y + rect->h+1}, new SDL_Point{0,-radius},
       new SDL_Point{0,0},new SDL_Point{radius,0});
     for(int i = 0; i < BEZIER_RESOLUTION; i++){
       for(int x =rect->x; x < corner[i].x; x++){
         draw_cb(x,corner[i].y);
       }
     }
-    free(corner);
 
     //Bottom Right
-    corner = bezier_corner(new SDL_Point{rect->x + rect->w + 1,rect->y + rect->h + 1}, new SDL_Point{0,-radius},
+    bezier_corner(corner, new SDL_Point{rect->x + rect->w + 1,rect->y + rect->h + 1}, new SDL_Point{0,-radius},
       new SDL_Point{0,0},new SDL_Point{-radius,0});
     for(int i = 0; i < BEZIER_RESOLUTION; i++){
       for(int x = rect->x+rect->w; x > corner[i].x; x--){
@@ -72,14 +72,42 @@ void smooth_corners(SDL_Rect *rect, int radius,function<void(int,int)> draw_cb){
 }
 void smooth_corners_surface(SDL_Surface*surface,Uint32 color,SDL_Rect*rect,int radius){
   smooth_corners(rect,radius,[&](int x,int y){
+    if(x >= surface->w || y >= surface->h || y < 0 || x < 0)
+      return;
     Uint8 * pixel = (Uint8*)surface->pixels;
     pixel += (y * surface->pitch) + (x * sizeof(Uint32));
     *((Uint32*)pixel) = color;
-    });
+  });
 }
 void smooth_corners_renderer(SDL_Renderer*renderer,argb*color,SDL_Rect*rect,int radius){
     SDL_SetRenderDrawColor(renderer,color->r,color->g,color->b,color->a);
     smooth_corners(rect,radius,[&](int x,int y){
       SDL_RenderDrawPoint(renderer,x,y);
     });
+}
+
+
+SDL_Surface* make_input_box(int inputWidth, int inputHeight, argb *color, int inputBoxRadius){
+
+  SDL_Rect inputRect;
+  inputRect.x = 1;
+  inputRect.y = 1;
+  inputRect.w = inputWidth + 3;
+  inputRect.h = inputHeight + 3;
+
+  SDL_Surface* surf;
+  #if SDL_BYTEORDER == SDL_BIG_ENDIAN
+    surf = SDL_CreateRGBSurface(SDL_SWSURFACE, inputRect.w, inputRect.h, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+  #else
+    surf = SDL_CreateRGBSurface(SDL_SWSURFACE, inputRect.w, inputRect.h, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+  #endif
+  SDL_FillRect(surf, &inputRect, SDL_MapRGBA(surf->format, color->r, color->g, color->b, color->a));
+
+  inputRect.w -= 2;
+  inputRect.h -= 2;
+  
+  if(inputBoxRadius > 0)
+    smooth_corners_surface(surf, SDL_MapRGBA(surf->format,0,0,0,0), &inputRect, inputBoxRadius);
+
+  return surf;
 }

--- a/draw_helpers.h
+++ b/draw_helpers.h
@@ -60,4 +60,13 @@ void smooth_corners_renderer(SDL_Renderer*renderer,argb*color,SDL_Rect*rect,int 
   @returns an array of pixel coordinates (length equal to BREZIER_RESOLUTION)
 */
 SDL_Point* bezier_corner (SDL_Point*offset,SDL_Point *p1, SDL_Point *p2, SDL_Point *p3);
+
+/**
+  Create an input box base off a given width, height, color and radius
+  @param inputWidth box's width
+  @param inputHeight box's height
+  @param color the box's background color
+  @param inputBoxRadius degree to curve the box's corners, if inputWidth == inputHeight and inputBoxRadius == inputWidth/2 the box should be a circle
+*/
+SDL_Surface* make_input_box(int inputWidth, int inputHeight, argb *color, int inputBoxRadius);
 #endif

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -108,11 +108,14 @@ float Keyboard::getHeight(){
 void Keyboard::draw(SDL_Renderer *renderer, int screenHeight){
   list<KeyboardLayer>::iterator layer;
   SDL_Rect keyboardRect, srcRect;
+  // These two variables set a limit on the precision of keyboard positioning
+  float position = floor(this->position * 100) / 100;
+  float targetPosition = floor(this->targetPosition * 100) / 100;
 
-  if (this->position > this->targetPosition){
-    this->position -= (this->position - this->targetPosition) / 10;
-  }else{
-    this->position += (this->targetPosition - this->position) / 10;
+  if (position > targetPosition){
+    this->position -= (position - targetPosition) / 10;
+  }else if (position < targetPosition){
+    this->position += (targetPosition - position) / 10;
   }
 
   keyboardRect.x = 0;

--- a/keyboard.h
+++ b/keyboard.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 #include <list>
+#include <cmath>
 
 
 const string KEYCAP_BACKSPACE = "\u2190";

--- a/util.cpp
+++ b/util.cpp
@@ -157,7 +157,25 @@ void draw_password_box(SDL_Renderer *renderer, int numDots, int screenHeight,
   return;
 }
 
-
+void draw_password_box_dots(SDL_Renderer* renderer, int inputHeight, int screenWidth, 
+                              int numDots, int y, bool busy){
+  int deflection = inputHeight / 4;
+  int ypos = y + inputHeight / 2;
+  float tick = (float) SDL_GetTicks();
+  // Draw password dots
+  int dotSize = screenWidth * 0.02;
+  for (int i = 0; i < numDots; i++) {
+    SDL_Point dotPos;
+    dotPos.x = (screenWidth / 10) + (i * dotSize * 3);
+    if (busy) {
+      dotPos.y = ypos + sin((tick / 100.0)+(i)) * deflection;
+    } else {
+      dotPos.y = ypos;
+    }
+    draw_circle(renderer, dotPos, dotSize);
+  }
+  return;
+}
 void handleVirtualKeyPress(string tapped, Keyboard *kbd, LuksDevice *lkd,
                            list<string> *passphrase){
   // return pressed

--- a/util.h
+++ b/util.h
@@ -105,4 +105,16 @@ void draw_password_box(SDL_Renderer *renderer, int numDots, int screenHeight,
 void handleVirtualKeyPress(string tapped, Keyboard *kbd, LuksDevice *lkd,
                            list<string> *passphrase);
 
+
+/**
+  Draw the dots to represent hidden characters
+  @param renderer Initialized SDL_Renderer object
+  @param inputHeight Height of input box
+  @param screenWidth Width of overall screen
+  @param numDots Number of password 'dots' to draw
+  @param y Vertical position of the input box
+  @param busy if true the dots will play a loading animation
+*/
+void draw_password_box_dots(SDL_Renderer* renderer, int inputHeight, int screenWidth, 
+                              int numDots, int y, bool busy);
 #endif


### PR DESCRIPTION
@IanS5 contributed improvements to inputbox rendering, his changes have
been merged/flattened into this commit. Thank you @IanS5
    
This implements 'render only when necessary' for drawing to the screen.
Screen updates are handled by pushing a new custom event EVENT_RENDER to
the event queue. The render timer cb has been removed, so this new
implementation removes any of the issues that previously existed with
multithreading.
    
CPU usage on the N900 is also drastically reduced: <1% when idle,
~10-20% when pressing keys, and 50-60% when running keyboard or unlock
animations (as measured very scientifically with 'top')
