### PR TITLE
Fix Makefile; replace surface by renderer API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,6 @@ clean:
 	-rm -rfv $(OBJ_DIR) $(BIN_DIR)
 
 directories:
-	@mkdir -p ./{bin,obj}
+	@mkdir -p ./obj
+	@mkdir -p ./bin
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **args) {
     exit(1);
   }
 
-  renderer = SDL_CreateRenderer(display, -1, SDL_RENDERER_SOFTWARE);
+  renderer = SDL_CreateRenderer(display, -1, 0);
 
   if (renderer == NULL) {
     SDL_LogError(SDL_LOG_CATEGORY_VIDEO,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,6 @@ int main(int argc, char **args) {
   Config config;
   SDL_Event event;
   SDL_Window *display = NULL;
-  SDL_Surface *screen = NULL;
   SDL_Renderer *renderer = NULL;
   Tooltip *tooltip = NULL;
   int WIDTH = 480;
@@ -101,7 +100,7 @@ int main(int argc, char **args) {
   }
 
   /*
-   * Set up display, renderer, & screen
+   * Set up display and renderer
    * Use windowed mode in test mode and device resolution otherwise
    */
   int windowFlags = 0;
@@ -130,15 +129,6 @@ int main(int argc, char **args) {
     exit(1);
   }
 
-  screen = SDL_GetWindowSurface(display);
-
-  if (screen == NULL) {
-    SDL_LogError(SDL_LOG_CATEGORY_VIDEO,
-                "ERROR: Could not get window surface: %s\n", SDL_GetError());
-    atexit(SDL_Quit);
-    exit(1);
-  }
-
   int keyboardHeight = HEIGHT / 3 * 2;
   if (HEIGHT > WIDTH) {
     // Keyboard height is screen width / max number of keys per row * rows
@@ -146,9 +136,14 @@ int main(int argc, char **args) {
   }
 
   int inputHeight = WIDTH / 10;
-  auto backgroundColor = SDL_MapRGB(screen->format, 255, 128, 0);
 
-  if (SDL_FillRect(screen, NULL, backgroundColor) != 0) {
+  if (SDL_SetRenderDrawColor(renderer, 255, 128, 0, SDL_ALPHA_OPAQUE) != 0) {
+    SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "ERROR: Could not set background color: %s\n", SDL_GetError());
+    atexit(SDL_Quit);
+    exit(1);
+  }
+
+  if (SDL_RenderFillRect(renderer, NULL) != 0) {
     SDL_LogError(SDL_LOG_CATEGORY_VIDEO,
                 "ERROR: Could not fill background color: %s\n",
                 SDL_GetError());


### PR DESCRIPTION
This contains one major and two small fixes (please tell me if you want separate PRs):

* In the Makefile, the `{obj,bin}` notation did not work under Alpine Linux which lead to a failing build. This replaces it by two lines.
* According to the documentation of [SDL_GetWindowSurface](https://wiki.libsdl.org/SDL_GetWindowSurface), the surface API and the renderer API must not be used at the same time. For me, this lead to errors because the function to create a renderer was called twice on the same window and the second call failed. I have fixed this by replacing the use of the surface API by the renderer API. This only concerns drawing the background which was trivial to replace.
* I do not see the advantage of using the software renderer when a hardware renderer like DirectFB is available. For me, the hint to use software rendering leads to having two renderers initialized: directfb and software. Removing the hint, the software renderer seems to not be used anymore. Unfortunately, the DirectFB renderer is not in the renderer list by default. This needs the following patch to SDL2:

```patch
diff --git a/src/render/SDL_render.c b/src/render/SDL_render.c
index 8cd3a7b..eacc7e2 100644
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -89,9 +89,7 @@ static const SDL_RenderDriver *render_drivers[] = {
 #if SDL_VIDEO_RENDER_OGL_ES
     &GLES_RenderDriver,
 #endif
-#if SDL_VIDEO_RENDER_DIRECTFB
     &DirectFB_RenderDriver,
-#endif
 #if SDL_VIDEO_RENDER_METAL
     &METAL_RenderDriver,
 #endif
```

Unfortunately, I couldn't figure out how to initialize the `DirectFB_RenderDriver` on my device (Samsung Note 8.0 (WiFi) n5110) without that patch. Unfortunately, there is also no way to set this define using the configure script (there are flags for some of the other renderers). If you don't have a better idea I would suggest to try to either get this patch into the Alpine package or alternatively to try to upstream a change that adds a flag to cleanly enable it using the configure script. Note that the directfb renderer is always compiled when directfb is enabled, it is only missing from the list of renderer drivers. Manually e.g. setting it e.g. as first item of the array using gdb also works.